### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = ""

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Kavi Voice Assistant
-
+[![Run on Repl.it](https://repl.it/badge/github/yemregundogmus/Kavi-Voice-Assistant)](https://repl.it/github/yemregundogmus/Kavi-Voice-Assistant)
 <img src="https://raw.githubusercontent.com/unforgiventr/Python-Derin-Ogrenme-The-Crew-Oto-Pilot/master/kavikapak.png" width="250" title="hover text">
 
 


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@LowerBite/Kavi-Voice-Assistant).